### PR TITLE
Improve SEO with updated title and meta description

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -2,9 +2,9 @@
 <head>
 <title>
 </title>
-<meta name="keywords" content="">
-<meta name="description" content="Map of Pi is a great app for all Pioneers. It’s the only app existing which enables Pioneers to easily find each other to Search, Buy, Sell using Pi directly between their Pi Wallets">
-</head>
+ <title>Map of Pi: Map Where You Can Find Local Shops That Accept Pi</title>
+  <meta name="description" content="Discover merchants accepting Pi cryptocurrency with Map of Pi. Search, buy, and sell local products and services within the Pi Network ecosystem.">
+  </head>
 
 <body>
 This is a mapofpi.com index.html page displayed when the url is typed into a browser. It should contain all the key search strings embedded within it to enable mapofpi to be top of a Google search result screen, as well as user-friendly information about Map of Pi, encouraging the user to access the app using a button on the page, and if not already a Pioneer encouraging the user to join Pi Network. it could also encourage users to like/follow/share our Map of Pi Facebook page, and encourage them to facilitate the friends to also do so.


### PR DESCRIPTION
Updated title and description meta tags for SEO. The prior use of keywords(now removed) is not current SEO as they should be actually embedded thru the homepage for proper indexing of the site(it helps the web crawler better understand context, insights and details and is standard).